### PR TITLE
fix `handleInput.vue` inputEvent type

### DIFF
--- a/docs/repl/components/InputHeader.vue
+++ b/docs/repl/components/InputHeader.vue
@@ -17,7 +17,7 @@ import { useOptions } from '../stores/options';
 
 const modulesStore = useModules();
 const optionsStore = useOptions();
-const handleInput = (event: InputEvent) =>
+const handleInput = (event: Event) =>
 	modulesStore.selectExample((event.target as HTMLSelectElement).value);
 const startOver = () => {
 	modulesStore.set([{ code: '', isEntry: true, name: 'main.js' }], '');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x]  refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
I read  `InputHeader.vue` file, find click event type incompatible.
Actual:
![屏幕截图 2023-03-11 135156](https://user-images.githubusercontent.com/17617116/224468286-8f933522-c935-44dc-9218-80d0a3a90934.png)
Expected:
![屏幕截图 2023-03-11 140234](https://user-images.githubusercontent.com/17617116/224468300-7b125f06-9595-47cf-9d10-9d5ea84bee5a.png)


